### PR TITLE
Ignore sqlite DBs and bundler paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .idea
+db/*.sqlite3
+
+# Bundler directories
+.bundle/
+vendor/


### PR DESCRIPTION
## Summary
- avoid committing SQLite database files
- ignore bundler-generated directories
- rerun bundler and rubocop to verify the environment

## Testing
- `bundle install --path vendor/bundle`
- `bundle exec rake rubocop`


------
https://chatgpt.com/codex/tasks/task_e_6857c11076d8832588de12b6ba9916b6